### PR TITLE
Fix transcript download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+runtime/

--- a/video/download.py
+++ b/video/download.py
@@ -1,19 +1,26 @@
-import yt_dlp
+import os
+import subprocess
+
+# Note to future selves and repo dwellers that we tried our best to use the yt-dlp library and it just doesn't work. don't waste time on it again :)
 
 # I have no idea
-def download_video(video_url, save_directory=None):
-    if save_directory is None:
-        save_directory = f"../downloads/{video_url.split("=")[1]}"
-    download_options = {
-        "write-subs": True,
-        "write-auto-subs": True,
-        "sub-lang": "en",
-        "sub-format": "webvtt",
-        "convert-subs": True,
-        "skip_download": True,
-        "outtmpl": f"{save_directory}/%(id)s.%(ext)s"
-    }
-    with yt_dlp.YoutubeDL(download_options) as ydl:
-        video_info = ydl.download([video_url])
-    return video_info
+def download_video(video_url):
+    # bit scrappy can convert this to parameter later
+    try:
+        os.makedirs("./runtime", exist_ok=True)
+    except:
+        print("[ERROR] Failed to make runtime directory")
 
+
+    args = [
+        "yt-dlp",
+        "--write-subs",
+        "--write-auto-subs",
+        "--sub-lang", "en",
+        "--sub-format", "webvtt",
+        "--skip-download",
+        "--output", "./runtime/%(id)s-transcript.%(ext)s",
+        video_url
+    ]
+
+    subprocess.run(args)


### PR DESCRIPTION
Transcripts now download properly into the `./runtime` directory.
You will need yt-dlp on the command line in order to run the program.