### PR TITLE
Word match patch

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from video.webvtt import WebVTT
 
 runtime_dir = ""
 
-
 # loads and handles init of environment variables
 def init_env():
     global runtime_dir
@@ -51,8 +50,6 @@ def main():
     # Singleton openai client, I'm sticking to gpt 4o mini for testing
     openai_client = OpenAIWrapper(os.getenv("OPENAI_KEY"), OpenAIModel.GPT_4O_MINI)
 
-    runtime_dir = "runtime"
-
     # download transcript and deserialize into WebVTT object
     download_transcript("https://www.youtube.com/watch?v=SHZAaGidUbg", runtime_dir)
     webvtt = WebVTT(runtime_dir + "/SHZAaGidUbg.en.vtt")
@@ -68,10 +65,9 @@ def main():
         start_index, end_index = find_subtext(transcript, line)
         start_time, end_time = webvtt.get_time_of_phrase(start_index, end_index)
         print(f"{line}: {start_time} --> {end_time}")
-
         times_to_keep.append((start_time.seconds(), end_time.seconds()))
 
-    trim_video("./runtime/SHZAaGidUbg.mp4", "out.mp4", times_to_keep)
+    trim_video("./runtime/SHZAaGidUbg.mp4", "SHZAaGidUbg.mp4", times_to_keep)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from api.openai_client import OpenAIModel, OpenAIWrapper, unwrap_response
+from process.ffmpeg_api import trim_video
 from process.match import find_subtext
 from video.download import download_transcript
 from video.webvtt import WebVTT
@@ -61,10 +62,17 @@ def main():
 
     # Probably gonna have an error like None has no attribute blah blah but who rlly cares
 
+    times_to_keep = []
+
     for line in summary.split("\n"):
         start_index, end_index = find_subtext(transcript, line)
         start_time, end_time = webvtt.get_time_of_phrase(start_index, end_index)
         print(f"{line}: {start_time} --> {end_time}")
+
+        times_to_keep.append((start_time.seconds(), end_time.seconds()))
+
+    trim_video("./runtime/SHZAaGidUbg.mp4", "out.mp4", times_to_keep)
+
 
 if __name__ == '__main__':
      main()

--- a/process/ffmpeg_api.py
+++ b/process/ffmpeg_api.py
@@ -1,5 +1,5 @@
-import subprocess
 import json
+import subprocess
 
 
 # ffmpeg trim function keeps the segments you provide it to trim (basically the opposite you'd expect)
@@ -39,7 +39,7 @@ def trim_video(input_path: str, output_path: str, cut_segments: list[(float, flo
         "-filter_complex", # now generate cut arguments...
     ]
 
-    keep_segments = _invert_segments(cut_segments, _ffprobe_video_length(input_path))
+    keep_segments = cut_segments # _invert_segments(cut_segments, _ffprobe_video_length(input_path))
 
     # appends specific trim arguments to arguments (one for audio one for video)
     trims = 0
@@ -59,7 +59,8 @@ def trim_video(input_path: str, output_path: str, cut_segments: list[(float, flo
     args.extend(["-map", "[outv]", "-map", "[outa]"])
     args.append(output_path)
 
-    # uncomment to view command.. print(" ".join(args))
+    # uncomment to view command.. 
+    print(" ".join(args))
     subprocess.run(args)
 
 

--- a/video/download.py
+++ b/video/download.py
@@ -8,18 +8,32 @@ def download_transcript(video_url, runtime_directory, overwrite = False):
 
     # TODO: Right now it assumes format https://youtube.com/watch?v=xxxxxxxxxxx
     video_id = video_url[len(video_url) - 11:]
-    if os.path.exists(runtime_directory + "/" + video_id + ".en.vtt") and not overwrite:
-        print("[INFO] File already downloaded, skipping download...")
-        return
+    subtitle_downloaded = os.path.exists(runtime_directory + "/" + video_id + ".en.vtt")
+    video_downloaded = os.path.exists(runtime_directory + "/" + video_id + ".mp4")
 
     args = [
         "yt-dlp",
-        "--write-auto-subs",
-        "-f 137+140",
-        "--sub-lang", "en",
-        "--sub-format", "webvtt",
         "--output", runtime_directory + "/%(id)s.%(ext)s",
-        video_url
     ]
 
+
+    if not video_downloaded or overwrite:
+        args.append("-f 137+140")
+    else:
+        args.append("--skip-download")
+        print("[info] video already downloaded, skipping downloading")
+
+    if not subtitle_downloaded or overwrite:
+        args.append("--write-auto-subs")
+        args.append("--sub-lang")
+        args.append("en")
+        args.append("--sub-format")
+        args.append("webvtt")
+    else:
+        print("[info] subtitles already downloaded, skipping download")
+
+    if subtitle_downloaded and video_downloaded and not overwrite:
+        return
+
+    args.append(video_url)
     subprocess.run(args)

--- a/video/download.py
+++ b/video/download.py
@@ -15,9 +15,9 @@ def download_transcript(video_url, runtime_directory, overwrite = False):
     args = [
         "yt-dlp",
         "--write-auto-subs",
+        "-f 137+140",
         "--sub-lang", "en",
         "--sub-format", "webvtt",
-        "--skip-download",
         "--output", runtime_directory + "/%(id)s.%(ext)s",
         video_url
     ]

--- a/video/webvtt.py
+++ b/video/webvtt.py
@@ -1,5 +1,6 @@
 import os
 
+
 class WebVTTUtil:
     @staticmethod
     def is_whitespace(string):


### PR DESCRIPTION
@jcowdells 
Merging my changes into the word-match branch.

On [this line](https://github.com/Mqlvin/brain-bites/blob/548ba321e01cfbba129443a34ee5c6af28257f22/main.py#L68), we need a milliseconds function (not just a seconds function). We will also probably need to add padding either side of this but thats for another commit.

The main issue I'm having is subtitles overlapping for some reason... illustrated by the output.
```
Every cloud has a silver lining except nuclear mushroom clouds which have a lining of strontium 90, cesium 137, and other radioactive isotopes.  : 00:00:00.280 --> 00:00:15.270
Upon detonation, atoms are literally gutted and glutton at temperatures exceeding that of the surface of our sun.  : 00:00:11.280 --> 00:00:23.830
In the 1950s, Harold Edgerton's rapatronic camera caught nuclear fireballs less than a thousandth of a second after detonation.  : 00:00:20.800 --> 00:00:33.670
```

I also smartened the downloader but that doesn't really matter.

Other than that, I've linked it up to the video parser and it works fine 💯 